### PR TITLE
wit/bindgen,cm: marshal & unmarshal for record types

### DIFF
--- a/cm/list.go
+++ b/cm/list.go
@@ -1,12 +1,29 @@
 package cm
 
-import "unsafe"
+import (
+	"encoding/json"
+	"unsafe"
+)
 
 // List represents a Component Model list.
 // The binary representation of list<T> is similar to a Go slice minus the cap field.
 type List[T any] struct {
 	_ HostLayout
 	list[T]
+}
+
+func (l List[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.Slice())
+}
+
+func (l *List[T]) UnmarshalJSON(buf []byte) error {
+	var data []T
+	err := json.Unmarshal(buf, &data)
+	if err != nil {
+		return err
+	}
+	*l = ToList(data)
+	return nil
 }
 
 // AnyList is a type constraint for generic functions that accept any [List] type.

--- a/cm/option.go
+++ b/cm/option.go
@@ -1,11 +1,36 @@
 package cm
 
+import (
+	"encoding/json"
+)
+
 // Option represents a Component Model [option<T>] type.
 //
 // [option<T>]: https://component-model.bytecodealliance.org/design/wit.html#options
 type Option[T any] struct {
 	_ HostLayout
 	option[T]
+}
+
+// MarshalJSON implements the json.Marshaler interface for [Option].
+func (o Option[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.Some())
+}
+
+// UnmarshalJSON unmarshals the Option from JSON.
+func (o *Option[T]) UnmarshalJSON(buf []byte) error {
+	if len(buf) == 0 {
+		*o = None[T]()
+		return nil
+	}
+
+	var v T
+	if err := json.Unmarshal(buf, &v); err != nil {
+		return err
+	}
+
+	*o = Some(v)
+	return nil
 }
 
 // None returns an [Option] representing the none case,

--- a/cm/tuple.go
+++ b/cm/tuple.go
@@ -1,5 +1,13 @@
 package cm
 
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ErrInvalidTuple is returned when a Tuple fails to unmarshal from JSON.
+var ErrInvalidTuple = errors.New("invalid tuple")
+
 // Tuple represents a [Component Model tuple] with 2 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -7,6 +15,30 @@ type Tuple[T0, T1 any] struct {
 	_  HostLayout
 	F0 T0
 	F1 T1
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple[T0, T1]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple[T0, T1]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 2 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple3 represents a [Component Model tuple] with 3 fields.
@@ -19,6 +51,32 @@ type Tuple3[T0, T1, T2 any] struct {
 	F2 T2
 }
 
+func (t Tuple3[T0, T1, T2]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple3[T0, T1, T2]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 3 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple4 represents a [Component Model tuple] with 4 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -28,6 +86,36 @@ type Tuple4[T0, T1, T2, T3 any] struct {
 	F1 T1
 	F2 T2
 	F3 T3
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple4[T0, T1, T2, T3]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple4[T0, T1, T2, T3]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 4 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple5 represents a [Component Model tuple] with 5 fields.
@@ -42,6 +130,39 @@ type Tuple5[T0, T1, T2, T3, T4 any] struct {
 	F4 T4
 }
 
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple5[T0, T1, T2, T3, T4]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple5[T0, T1, T2, T3, T4]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 5 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple6 represents a [Component Model tuple] with 6 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -53,6 +174,42 @@ type Tuple6[T0, T1, T2, T3, T4, T5 any] struct {
 	F3 T3
 	F4 T4
 	F5 T5
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple6[T0, T1, T2, T3, T4, T5]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple6[T0, T1, T2, T3, T4, T5]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 6 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple7 represents a [Component Model tuple] with 7 fields.
@@ -69,6 +226,45 @@ type Tuple7[T0, T1, T2, T3, T4, T5, T6 any] struct {
 	F6 T6
 }
 
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple7[T0, T1, T2, T3, T4, T5, T6]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple7[T0, T1, T2, T3, T4, T5, T6]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 7 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple8 represents a [Component Model tuple] with 8 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -82,6 +278,48 @@ type Tuple8[T0, T1, T2, T3, T4, T5, T6, T7 any] struct {
 	F5 T5
 	F6 T6
 	F7 T7
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple8[T0, T1, T2, T3, T4, T5, T6, T7]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple8[T0, T1, T2, T3, T4, T5, T6, T7]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 8 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple9 represents a [Component Model tuple] with 9 fields.
@@ -100,6 +338,51 @@ type Tuple9[T0, T1, T2, T3, T4, T5, T6, T7, T8 any] struct {
 	F8 T8
 }
 
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple9[T0, T1, T2, T3, T4, T5, T6, T7, T8]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple9[T0, T1, T2, T3, T4, T5, T6, T7, T8]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 9 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple10 represents a [Component Model tuple] with 10 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -115,6 +398,54 @@ type Tuple10[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9 any] struct {
 	F7 T7
 	F8 T8
 	F9 T9
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple10[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple10[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 10 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple11 represents a [Component Model tuple] with 11 fields.
@@ -135,6 +466,57 @@ type Tuple11[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10 any] struct {
 	F10 T10
 }
 
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple11[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9, t.F10}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple11[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 11 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[10], &t.F10); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple12 represents a [Component Model tuple] with 12 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -152,6 +534,60 @@ type Tuple12[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11 any] struct {
 	F9  T9
 	F10 T10
 	F11 T11
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple12[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9, t.F10, t.F11}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple12[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 12 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[10], &t.F10); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[11], &t.F11); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple13 represents a [Component Model tuple] with 13 fields.
@@ -174,6 +610,63 @@ type Tuple13[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12 any] struct {
 	F12 T12
 }
 
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple13[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9, t.F10, t.F11, t.F12}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple13[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 13 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[10], &t.F10); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[11], &t.F11); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[12], &t.F12); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple14 represents a [Component Model tuple] with 14 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -193,6 +686,66 @@ type Tuple14[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13 any] str
 	F11 T11
 	F12 T12
 	F13 T13
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple14[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9, t.F10, t.F11, t.F12, t.F13}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple14[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 14 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[10], &t.F10); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[11], &t.F11); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[12], &t.F12); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[13], &t.F13); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Tuple15 represents a [Component Model tuple] with 15 fields.
@@ -217,6 +770,69 @@ type Tuple15[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14 any
 	F14 T14
 }
 
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple15[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9, t.F10, t.F11, t.F12, t.F13, t.F14}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple15[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 15 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[10], &t.F10); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[11], &t.F11); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[12], &t.F12); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[13], &t.F13); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[14], &t.F14); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Tuple16 represents a [Component Model tuple] with 16 fields.
 //
 // [Component Model tuple]: https://component-model.bytecodealliance.org/design/wit.html#tuples
@@ -238,6 +854,72 @@ type Tuple16[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T1
 	F13 T13
 	F14 T14
 	F15 T15
+}
+
+// MarshalJSON marshals the Tuple into JSON.
+func (t Tuple16[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16]) MarshalJSON() ([]byte, error) {
+	l := []any{t.F0, t.F1, t.F2, t.F3, t.F4, t.F5, t.F6, t.F7, t.F8, t.F9, t.F10, t.F11, t.F12, t.F13, t.F14, t.F15}
+	return json.Marshal(l)
+}
+
+// UnmarshalJSON unmarshals the Tuple from JSON.
+func (t *Tuple16[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]) UnmarshalJSON(buf []byte) error {
+	tmp := []json.RawMessage{}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) != 16 {
+		return ErrInvalidTuple
+	}
+	if err := json.Unmarshal(tmp[0], &t.F0); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[1], &t.F1); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[2], &t.F2); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[3], &t.F3); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[4], &t.F4); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[5], &t.F5); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[6], &t.F6); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[7], &t.F7); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[8], &t.F8); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[9], &t.F9); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[10], &t.F10); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[11], &t.F11); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[12], &t.F12); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[13], &t.F13); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[14], &t.F14); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tmp[15], &t.F15); err != nil {
+		return err
+	}
+	return nil
 }
 
 // MaxTuple specifies the maximum number of fields in a Tuple* type, currently [Tuple16].

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -1,6 +1,8 @@
 package cm
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // Discriminant is the set of types that can represent the tag or discriminator of a variant.
 // Use bool for 2-case variant types, result<T>, or option<T> types, uint8 where there are 256 or


### PR DESCRIPTION
Adds `json` struct tags to Records, based on wit names.

Also adds `MarshalJSON` & `UnmarshalJSON` to:
- cm.List
- cm.Tuple ( all of them )
- cm.Option
- cm.Variant

Example, encoding a complex record type:
```
  record response {
      headers: list<tuple<string, list<string>>>,
      http-code: u16,
      body: response-body
  }
  variant response-body {
    ok(list<list-element>),
    err(function-error),
    platform-err(platform-error)
  }
  record list-element {
      optional-int: option<u64>,
      optional-bool: option<bool>,
  }
  record function-error {
      error: string
  }
  record platform-error {
    code: string,
    message: string
  }
```

and filling it up:

```
	hdrVals := cm.ToList([]string{"value1", "value2"})
	hdrTuple := cm.Tuple[string, cm.List[string]]{
		F0: "header-name",
		F1: hdrVals,
	}
	headers := cm.ToList([]cm.Tuple[string, cm.List[string]]{hdrTuple})
	v := somefunctioninterface.Response{
		Headers:  headers,
		HTTPCode: 200,
		Body:     somefunctioninterface.ResponseBodyErr(somefunctioninterface.FunctionError{Error: "failed"}),
	}
```

Without this Pull Request:
```
{"Headers":{},"Body":{"RequiredParam":"required","OptionalParam":{}}}
```

With this Pull Request:

```
{"headers":[["header-name",["value1","value2"]]],"http-code":200,"body":{"err":{"error":"failed"}}}
```

## Tuple handling
Tuples are encoded as json arrays with explicit `null`s.
```
Tuple[string,int] -> [ "some string", 42 ]
Tuple3[string, *string, int] -> [ "some string", null, 42 ]
```

## Variant handling
Variants are encoded as json dictionaries, so they can carry the variant data.
```
 record somerecord {
   myvariant: somevar,
 }
  variant somevar {
    ok,
    err(string),
  }

// JSON
{ "myvariant": { "ok": true }}
{ "myvariant": { "error": "error value" }}
```

## Option handling
Options rely on explicit `null` for the "None" case.
```
{ "myoptional": null } // cm.None
{ "myoptional": "this" } // cm.Option[string]
```

If this direction seems reasonable I will add:
- Marshal/Unmarshal to `cm.Result`
- Encoding/Decoding Tests