### PR TITLE
wit/bindgen: correctly handle cyclical type dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [#240](https://github.com/bytecodealliance/go-modules/issues/240): correctly handle cyclical data structures when generating variant lowering code.
+
 ## [v0.4.0] — 2024-11-05
 
 This module has been renamed. Going forward, please use `go.bytecodealliance.org` instead of `github.com/bytecodealliance/wasm-tools-go`.

--- a/testdata/issues/issue240.wit
+++ b/testdata/issues/issue240.wit
@@ -1,0 +1,17 @@
+package issues:issue240;
+
+interface i {
+	// v refers to r
+	variant v {
+		one(r),
+	}
+
+	// r refers to v
+	resource r {
+		f: func(param: v);
+	}
+}
+
+world w {
+    import i;
+}

--- a/testdata/issues/issue240.wit.json
+++ b/testdata/issues/issue240.wit.json
@@ -1,0 +1,105 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i",
+      "types": {
+        "r": 0,
+        "v": 2
+      },
+      "functions": {
+        "[method]r.f": {
+          "name": "[method]r.f",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 3
+            },
+            {
+              "name": "param",
+              "type": 2
+            }
+          ],
+          "results": []
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "r",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      },
+      "docs": {
+        "contents": "r refers to v"
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 0
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": "v",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "one",
+              "type": 1
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      },
+      "docs": {
+        "contents": "v refers to r"
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue240",
+      "interfaces": {
+        "i": 0
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue240.wit.json.golden.wit
+++ b/testdata/issues/issue240.wit.json.golden.wit
@@ -1,0 +1,15 @@
+package issues:issue240;
+
+interface i {
+	/// r refers to v
+	resource r {
+		f: func(param: v);
+	}
+
+	/// v refers to r
+	variant v { one(r) }
+}
+
+world w {
+	import i;
+}

--- a/testdata/issues/issue242.wit
+++ b/testdata/issues/issue242.wit
@@ -1,0 +1,15 @@
+package issues:issue242;
+
+interface i {
+	variant v {
+		a,
+		b,
+		// tag might collide with (cm.Variant).Tag() method
+		tag,
+		%string(string),
+	}
+}
+
+world w {
+	import i;
+}

--- a/testdata/issues/issue242.wit.json
+++ b/testdata/issues/issue242.wit.json
@@ -1,0 +1,70 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i",
+      "types": {
+        "v": 0
+      },
+      "functions": {},
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "v",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "a",
+              "type": null
+            },
+            {
+              "name": "b",
+              "type": null
+            },
+            {
+              "name": "tag",
+              "type": null,
+              "docs": {
+                "contents": "tag might collide with (cm.Variant).Tag() method"
+              }
+            },
+            {
+              "name": "string",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue242",
+      "interfaces": {
+        "i": 0
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue242.wit.json.golden.wit
+++ b/testdata/issues/issue242.wit.json.golden.wit
@@ -1,0 +1,15 @@
+package issues:issue242;
+
+interface i {
+	variant v {
+		a,
+		b,
+		/// tag might collide with (cm.Variant).Tag() method
+		tag,
+		%string(string),
+	}
+}
+
+world w {
+	import i;
+}

--- a/tests/generated/wasi/filesystem/v0.2.0/types/abi.go
+++ b/tests/generated/wasi/filesystem/v0.2.0/types/abi.go
@@ -30,7 +30,7 @@ func lower_NewTimestamp(v NewTimestamp) (f0 uint32, f1 uint64, f2 uint32) {
 	f0 = (uint32)(v.Tag())
 	switch f0 {
 	case 2: // timestamp
-		v1, v2 := lower_DateTime(*v.Timestamp())
+		v1, v2 := lower_DateTime(*cm.Case[DateTime](&v, 2))
 		f1 = (uint64)(v1)
 		f2 = (uint32)(v2)
 	}

--- a/tests/generated/wasi/sockets/v0.2.0/tcp/abi.go
+++ b/tests/generated/wasi/sockets/v0.2.0/tcp/abi.go
@@ -64,14 +64,14 @@ func lower_IPSocketAddress(v network.IPSocketAddress) (f0 uint32, f1 uint32, f2 
 	f0 = (uint32)(v.Tag())
 	switch f0 {
 	case 0: // ipv4
-		v1, v2, v3, v4, v5 := lower_IPv4SocketAddress(*v.IPv4())
+		v1, v2, v3, v4, v5 := lower_IPv4SocketAddress(*cm.Case[network.IPv4SocketAddress](&v, 0))
 		f1 = (uint32)(v1)
 		f2 = (uint32)(v2)
 		f3 = (uint32)(v3)
 		f4 = (uint32)(v4)
 		f5 = (uint32)(v5)
 	case 1: // ipv6
-		v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11 := lower_IPv6SocketAddress(*v.IPv6())
+		v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11 := lower_IPv6SocketAddress(*cm.Case[network.IPv6SocketAddress](&v, 1))
 		f1 = (uint32)(v1)
 		f2 = (uint32)(v2)
 		f3 = (uint32)(v3)

--- a/tests/generated/wasi/sockets/v0.2.0/udp/abi.go
+++ b/tests/generated/wasi/sockets/v0.2.0/udp/abi.go
@@ -52,14 +52,14 @@ func lower_IPSocketAddress(v network.IPSocketAddress) (f0 uint32, f1 uint32, f2 
 	f0 = (uint32)(v.Tag())
 	switch f0 {
 	case 0: // ipv4
-		v1, v2, v3, v4, v5 := lower_IPv4SocketAddress(*v.IPv4())
+		v1, v2, v3, v4, v5 := lower_IPv4SocketAddress(*cm.Case[network.IPv4SocketAddress](&v, 0))
 		f1 = (uint32)(v1)
 		f2 = (uint32)(v2)
 		f3 = (uint32)(v3)
 		f4 = (uint32)(v4)
 		f5 = (uint32)(v5)
 	case 1: // ipv6
-		v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11 := lower_IPv6SocketAddress(*v.IPv6())
+		v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11 := lower_IPv6SocketAddress(*cm.Case[network.IPv6SocketAddress](&v, 1))
 		f1 = (uint32)(v1)
 		f2 = (uint32)(v2)
 		f3 = (uint32)(v3)

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -863,7 +863,7 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, t *wit.TypeDef
 		if c.Type == nil {
 			stringio.Write(&b, "var ", dataName, " ", typeRep, "\n")
 		}
-		stringio.Write(&b, "return ", cm, ".New[", goName, "](", caseNum, ", ", dataName, ")\n")
+		stringio.Write(&b, "return ", g.cmCall(file, "New["+goName+"]", caseNum+", "+dataName), "\n")
 		b.WriteString("}\n\n")
 
 		// Emit getter
@@ -877,7 +877,7 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, t *wit.TypeDef
 			// Case with associated type T returns *T
 			stringio.Write(&b, "// ", caseName, " returns a non-nil *[", typeRep, "] if [", goName, "] represents the variant case \"", c.Name, "\".\n")
 			stringio.Write(&b, "func (self *", goName, ") ", caseName, "() *", typeRep, " {\n")
-			stringio.Write(&b, "return ", cm, ".Case[", typeRep, "](self, ", caseNum, ")")
+			stringio.Write(&b, "return ", g.cmCall(file, "Case["+typeRep+"]", "self, "+caseNum))
 			b.WriteString("}\n\n")
 		}
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -539,8 +539,11 @@ func (g *generator) declareTypeDef(file *gen.File, dir wit.Direction, t *wit.Typ
 
 	// Predeclare reserved methods.
 	switch t.Kind.(type) {
+	case *wit.Enum:
+		decl.scope.DeclareName("String") // For fmt.Stringer
 	case *wit.Variant:
-		decl.scope.DeclareName("Tag")
+		decl.scope.DeclareName("Tag")    // Method on cm.Variant
+		decl.scope.DeclareName("String") // For fmt.Stringer
 	}
 
 	return decl, nil
@@ -836,7 +839,6 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, t *wit.TypeDef
 
 	decl, _ := g.typeDecl(dir, t)
 	scope := decl.scope
-	scope.DeclareName("String") // For fmt.Stringer
 
 	// Emit type
 	var b strings.Builder

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1124,7 +1124,7 @@ func (g *generator) lowerFlags(file *gen.File, dir wit.Direction, t *wit.TypeDef
 }
 
 func (g *generator) lowerVariant(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
-	decl, _ := g.typeDecl(dir, t)
+	// decl, _ := g.typeDecl(dir, t)
 	v := t.Kind.(*wit.Variant)
 	flat := t.Flat()
 	if v.Enum() != nil {
@@ -1139,9 +1139,10 @@ func (g *generator) lowerVariant(file *gen.File, dir wit.Direction, t *wit.TypeD
 			continue
 		}
 		caseNum := strconv.Itoa(i)
-		caseName := decl.scope.GetName(GoName(c.Name, true))
+		// caseName := decl.scope.GetName(GoName(c.Name, true))
+		input := "*" + g.cmCall(abiFile, "Case["+g.typeRep(file, dir, c.Type)+"]", "&v, "+caseNum)
 		stringio.Write(&b, "case ", caseNum, ": // ", c.Name, "\n")
-		b.WriteString(g.lowerVariantCaseInto(abiFile, dir, c.Type, flat[1:], "*v."+caseName+"()"))
+		b.WriteString(g.lowerVariantCaseInto(abiFile, dir, c.Type, flat[1:], input))
 	}
 	b.WriteString("}\n")
 	b.WriteString("return\n")


### PR DESCRIPTION
Correctly generate variant lowering code when a `variant` depends on a `resource`, and the `resource` depends on the `variant`.

Fixes #240 and #242.