### PR TITLE
wit/bindgen: Add JSON tag to Record structs

### DIFF
--- a/tests/generated/wasi/clocks/v0.2.0/wall-clock/wall-clock.wit.go
+++ b/tests/generated/wasi/clocks/v0.2.0/wall-clock/wall-clock.wit.go
@@ -31,9 +31,9 @@ import (
 //		nanoseconds: u32,
 //	}
 type DateTime struct {
-	_           cm.HostLayout
-	Seconds     uint64
-	Nanoseconds uint32
+	_           cm.HostLayout `json:"-"`
+	Seconds     uint64        `json:"seconds"`
+	Nanoseconds uint32        `json:"nanoseconds"`
 }
 
 // Now represents the imported function "now".

--- a/tests/generated/wasi/filesystem/v0.2.0/types/types.wit.go
+++ b/tests/generated/wasi/filesystem/v0.2.0/types/types.wit.go
@@ -246,34 +246,34 @@ type LinkCount uint64
 //		status-change-timestamp: option<datetime>,
 //	}
 type DescriptorStat struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// File type.
-	Type DescriptorType
+	Type DescriptorType `json:"type"`
 
 	// Number of hard links to the file.
-	LinkCount LinkCount
+	LinkCount LinkCount `json:"link-count"`
 
 	// For regular files, the file size in bytes. For symbolic links, the
 	// length in bytes of the pathname contained in the symbolic link.
-	Size FileSize
+	Size FileSize `json:"size"`
 
 	// Last data access timestamp.
 	//
 	// If the `option` is none, the platform doesn't maintain an access
 	// timestamp for this file.
-	DataAccessTimestamp cm.Option[DateTime]
+	DataAccessTimestamp cm.Option[DateTime] `json:"data-access-timestamp"`
 
 	// Last data modification timestamp.
 	//
 	// If the `option` is none, the platform doesn't maintain a
 	// modification timestamp for this file.
-	DataModificationTimestamp cm.Option[DateTime]
+	DataModificationTimestamp cm.Option[DateTime] `json:"data-modification-timestamp"`
 
 	// Last file status-change timestamp.
 	//
 	// If the `option` is none, the platform doesn't maintain a
 	// status-change timestamp for this file.
-	StatusChangeTimestamp cm.Option[DateTime]
+	StatusChangeTimestamp cm.Option[DateTime] `json:"status-change-timestamp"`
 }
 
 // NewTimestamp represents the variant "wasi:filesystem/types@0.2.0#new-timestamp".
@@ -346,12 +346,12 @@ func (v NewTimestamp) String() string {
 //		name: string,
 //	}
 type DirectoryEntry struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// The type of the file referred to by this directory entry.
-	Type DescriptorType
+	Type DescriptorType `json:"type"`
 
 	// The name of the object.
-	Name string
+	Name string `json:"name"`
 }
 
 // ErrorCode represents the enum "wasi:filesystem/types@0.2.0#error-code".
@@ -625,12 +625,12 @@ func (e Advice) String() string {
 //		upper: u64,
 //	}
 type MetadataHashValue struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// 64 bits of a 128-bit hash value.
-	Lower uint64
+	Lower uint64 `json:"lower"`
 
 	// Another 64 bits of a 128-bit hash value.
-	Upper uint64
+	Upper uint64 `json:"upper"`
 }
 
 // Descriptor represents the imported resource "wasi:filesystem/types@0.2.0#descriptor".

--- a/tests/generated/wasi/sockets/v0.2.0/network/network.wit.go
+++ b/tests/generated/wasi/sockets/v0.2.0/network/network.wit.go
@@ -263,12 +263,12 @@ func (v IPAddress) String() string {
 //		address: ipv4-address,
 //	}
 type IPv4SocketAddress struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// sin_port
-	Port uint16
+	Port uint16 `json:"port"`
 
 	// sin_addr
-	Address IPv4Address
+	Address IPv4Address `json:"address"`
 }
 
 // IPv6SocketAddress represents the record "wasi:sockets/network@0.2.0#ipv6-socket-address".
@@ -280,18 +280,18 @@ type IPv4SocketAddress struct {
 //		scope-id: u32,
 //	}
 type IPv6SocketAddress struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// sin6_port
-	Port uint16
+	Port uint16 `json:"port"`
 
 	// sin6_flowinfo
-	FlowInfo uint32
+	FlowInfo uint32 `json:"flow-info"`
 
 	// sin6_addr
-	Address IPv6Address
+	Address IPv6Address `json:"address"`
 
 	// sin6_scope_id
-	ScopeID uint32
+	ScopeID uint32 `json:"scope-id"`
 }
 
 // IPSocketAddress represents the variant "wasi:sockets/network@0.2.0#ip-socket-address".

--- a/tests/generated/wasi/sockets/v0.2.0/udp/udp.wit.go
+++ b/tests/generated/wasi/sockets/v0.2.0/udp/udp.wit.go
@@ -43,11 +43,11 @@ type IPAddressFamily = network.IPAddressFamily
 //		remote-address: ip-socket-address,
 //	}
 type IncomingDatagram struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// The payload.
 	//
 	// Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
-	Data cm.List[uint8]
+	Data cm.List[uint8] `json:"data"`
 
 	// The source address.
 	//
@@ -55,7 +55,7 @@ type IncomingDatagram struct {
 	// with, if any.
 	//
 	// Equivalent to the `src_addr` out parameter of `recvfrom`.
-	RemoteAddress IPSocketAddress
+	RemoteAddress IPSocketAddress `json:"remote-address"`
 }
 
 // OutgoingDatagram represents the record "wasi:sockets/udp@0.2.0#outgoing-datagram".
@@ -67,9 +67,9 @@ type IncomingDatagram struct {
 //		remote-address: option<ip-socket-address>,
 //	}
 type OutgoingDatagram struct {
-	_ cm.HostLayout
+	_ cm.HostLayout `json:"-"`
 	// The payload.
-	Data cm.List[uint8]
+	Data cm.List[uint8] `json:"data"`
 
 	// The destination address.
 	//
@@ -80,7 +80,7 @@ type OutgoingDatagram struct {
 	//
 	// If this value is None, the send operation is equivalent to `send` in POSIX. Otherwise
 	// it is equivalent to `sendto`.
-	RemoteAddress cm.Option[IPSocketAddress]
+	RemoteAddress cm.Option[IPSocketAddress] `json:"remote-address"`
 }
 
 // UDPSocket represents the imported resource "wasi:sockets/udp@0.2.0#udp-socket".

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -719,13 +719,13 @@ func (g *generator) recordRep(file *gen.File, dir wit.Direction, r *wit.Record, 
 	exported := len(goName) == 0 || token.IsExported(goName)
 	var b strings.Builder
 	b.WriteString("struct {\n")
-	stringio.Write(&b, "_ ", file.Import(g.opts.cmPackage), ".HostLayout")
+	stringio.Write(&b, "_ ", file.Import(g.opts.cmPackage), ".HostLayout `json:\"-\"`")
 	for i, f := range r.Fields {
 		if i == 0 || i > 0 && f.Docs.Contents != "" {
 			b.WriteRune('\n')
 		}
 		b.WriteString(formatDocComments(f.Docs.Contents, false))
-		stringio.Write(&b, fieldName(f.Name, exported), " ", g.typeRep(file, dir, f.Type), "\n")
+		stringio.Write(&b, fieldName(f.Name, exported), " ", g.typeRep(file, dir, f.Type), " `json:\"", f.Name, "\"`\n")
 	}
 	b.WriteRune('}')
 	return b.String()


### PR DESCRIPTION
Related to #239 

`HostLayout` receives `json:"-"` and any other field receives the original wit name.

```
// DateTime represents the record "wasi:clocks/wall-clock@0.2.0#datetime".
//
// A time and date in seconds plus nanoseconds.
//
//	record datetime {
//		seconds: u64,
//		nanoseconds: u32,
//	}
type DateTime struct {
	_           cm.HostLayout `json:"-"`
	Seconds     uint64        `json:"seconds"`
	Nanoseconds uint32        `json:"nanoseconds"`
}
```
