### PR TITLE
wit/bindgen: correctly cast to named Go bool types when lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [#264](https://github.com/bytecodealliance/go-modules/issues/264): fix lowering for imported functions that return named `bool` types.
+
 ## [v0.4.1] — 2024-12-09
 
 ### Added

--- a/testdata/issues/issue264.wit
+++ b/testdata/issues/issue264.wit
@@ -1,0 +1,10 @@
+package issues:issue264;
+
+interface i {
+	type boolean = bool;
+	f: func() -> boolean;
+}
+
+world w {
+	import i;
+}

--- a/testdata/issues/issue264.wit.json
+++ b/testdata/issues/issue264.wit.json
@@ -1,0 +1,59 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i",
+      "types": {
+        "boolean": 0
+      },
+      "functions": {
+        "f": {
+          "name": "f",
+          "kind": "freestanding",
+          "params": [],
+          "results": [
+            {
+              "type": 0
+            }
+          ]
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "boolean",
+      "kind": {
+        "type": "bool"
+      },
+      "owner": {
+        "interface": 0
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue264",
+      "interfaces": {
+        "i": 0
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue264.wit.json.golden.wit
+++ b/testdata/issues/issue264.wit.json.golden.wit
@@ -1,0 +1,10 @@
+package issues:issue264;
+
+interface i {
+	type boolean = bool;
+	f: func() -> boolean;
+}
+
+world w {
+	import i;
+}

--- a/tests/generated/wasi/cli/v0.2.0/exit/exit.wit.go
+++ b/tests/generated/wasi/cli/v0.2.0/exit/exit.wit.go
@@ -15,7 +15,7 @@ import (
 //
 //go:nosplit
 func Exit(status cm.BoolResult) {
-	status0 := cm.BoolToU32(status)
+	status0 := (uint32)(cm.BoolToU32(status))
 	wasmimport_Exit((uint32)(status0))
 	return
 }

--- a/tests/generated/wasi/cli/v0.2.0/run/run.wasm.go
+++ b/tests/generated/wasi/cli/v0.2.0/run/run.wasm.go
@@ -12,6 +12,6 @@ import (
 //export wasi:cli/run@0.2.0#run
 func wasmexport_Run() (result0 uint32) {
 	result := Exports.Run()
-	result0 = cm.BoolToU32(result)
+	result0 = (uint32)(cm.BoolToU32(result))
 	return
 }

--- a/tests/generated/wasi/filesystem/v0.2.0/types/types.wit.go
+++ b/tests/generated/wasi/filesystem/v0.2.0/types/types.wit.go
@@ -761,7 +761,7 @@ func (self Descriptor) IsSameObject(other Descriptor) (result bool) {
 	self0 := cm.Reinterpret[uint32](self)
 	other0 := cm.Reinterpret[uint32](other)
 	result0 := wasmimport_DescriptorIsSameObject((uint32)(self0), (uint32)(other0))
-	result = cm.U32ToBool((uint32)(result0))
+	result = (bool)(cm.U32ToBool((uint32)(result0)))
 	return
 }
 

--- a/tests/generated/wasi/io/v0.2.0/poll/poll.wit.go
+++ b/tests/generated/wasi/io/v0.2.0/poll/poll.wit.go
@@ -57,7 +57,7 @@ func (self Pollable) Block() {
 func (self Pollable) Ready() (result bool) {
 	self0 := cm.Reinterpret[uint32](self)
 	result0 := wasmimport_PollableReady((uint32)(self0))
-	result = cm.U32ToBool((uint32)(result0))
+	result = (bool)(cm.U32ToBool((uint32)(result0)))
 	return
 }
 

--- a/tests/generated/wasi/sockets/v0.2.0/tcp/tcp.wit.go
+++ b/tests/generated/wasi/sockets/v0.2.0/tcp/tcp.wit.go
@@ -241,7 +241,7 @@ func (self TCPSocket) HopLimit() (result cm.Result[uint8, uint8, ErrorCode]) {
 func (self TCPSocket) IsListening() (result bool) {
 	self0 := cm.Reinterpret[uint32](self)
 	result0 := wasmimport_TCPSocketIsListening((uint32)(self0))
-	result = cm.U32ToBool((uint32)(result0))
+	result = (bool)(cm.U32ToBool((uint32)(result0)))
 	return
 }
 
@@ -457,7 +457,7 @@ func (self TCPSocket) SetKeepAliveCount(value uint32) (result cm.Result[ErrorCod
 //go:nosplit
 func (self TCPSocket) SetKeepAliveEnabled(value bool) (result cm.Result[ErrorCode, struct{}, ErrorCode]) {
 	self0 := cm.Reinterpret[uint32](self)
-	value0 := cm.BoolToU32(value)
+	value0 := (uint32)(cm.BoolToU32(value))
 	wasmimport_TCPSocketSetKeepAliveEnabled((uint32)(self0), (uint32)(value0), &result)
 	return
 }

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1456,7 +1456,7 @@ func (g *generator) cast(file *gen.File, dir wit.Direction, from, to wit.Type, i
 	if t != nil {
 		return g.cmCall(file, goKind(from)+"To"+goKind(to)+"["+g.typeRep(file, dir, t)+"]", input)
 	}
-	return g.cmCall(file, goKind(from)+"To"+goKind(to), input)
+	return "(" + g.typeRep(file, dir, to) + ")(" + g.cmCall(file, goKind(from)+"To"+goKind(to), input) + ")"
 }
 
 func goKind(t wit.Node) string {


### PR DESCRIPTION
Fixes #264.

- **testdata/issues: add example for #264**
- **wit/bindgen: ensure primtives are cast to correct Go types**
- **tests/generated/wasi: regenerate**
