### PR TITLE
cm: use consistent pattern for wasmimport functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Initial support for Component Model [async](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Async.md) types `stream`, `future`, and `error-context`.
 - [`wasm-tools`](https://crates.io/crates/wasm-tools) is now vendored as a WebAssembly module, executed using [Wazero](https://wazero.io/). This allows package `wit` and `wit-bindgen-go` to run on any supported platform without needing to separately install `wasm-tools`.
 
 ### Changed
 
-- Initial support for Component Model [async](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Async.md) types `stream`, `future`, and `error-context`.
 - Breaking: generated `*.wasm.go` files will now have correct WIT kebab-case base name. Interfaces or worlds with `-` in their name will require removal of the previous `*.wasm.go` files.
 - Dropped support for TinyGo v0.32.0.
 

--- a/cm/error.go
+++ b/cm/error.go
@@ -28,21 +28,13 @@ func (err errorContext) String() string {
 // [error-context.debug-message]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#error-contextdebug-message
 func (err errorContext) DebugMessage() string {
 	var s string
-	errorContextDebugMessage(err, unsafe.Pointer(&s))
+	wasmimport_errorContextDebugMessage(err, unsafe.Pointer(&s))
 	return s
 }
-
-//go:wasmimport canon error-context.debug-message
-//go:noescape
-func errorContextDebugMessage(err errorContext, msg unsafe.Pointer)
 
 // Drop represents the Canonical ABI [error-context.drop] function.
 //
 // [error-context.drop]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#error-contextdrop
 func (err errorContext) Drop() {
-	errorContextDrop(err)
+	wasmimport_errorContextDrop(err)
 }
-
-//go:wasmimport canon error-context.drop
-//go:noescape
-func errorContextDrop(err errorContext)

--- a/cm/error.wasm.go
+++ b/cm/error.wasm.go
@@ -1,0 +1,13 @@
+package cm
+
+import "unsafe"
+
+// msg uses unsafe.Pointer for compatibility with go1.23 and lower.
+//
+//go:wasmimport canon error-context.debug-message
+//go:noescape
+func wasmimport_errorContextDebugMessage(err errorContext, msg unsafe.Pointer)
+
+//go:wasmimport canon error-context.drop
+//go:noescape
+func wasmimport_errorContextDrop(err errorContext)


### PR DESCRIPTION
- **CHANGELOG: move async types to Added section**
- **cm: follow pattern of generated wasmimport calls**
