### PR TITLE
wit/bindgen: fix wasm-tools WIT generation bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- [#281](https://github.com/bytecodealliance/go-modules/issues/281): errors from internal `wasm-tools` calls are no longer silently ignored. This required fixing a number of related issues, including synthetic world packages for Component Model metadata generation, WIT generation, and WIT keyword escaping in WIT package or interface names.
 - [#284](https://github.com/bytecodealliance/go-modules/issues/284): do not use `bool` for `variant` or `result` GC shapes. TinyGo returns `result` and `variant` values with `bool` as 0 or 1, which breaks the memory representation of tagged unions (variants).
 
 ## [v0.5.0] — 2024-12-14

--- a/testdata/issues/issue281.wit
+++ b/testdata/issues/issue281.wit
@@ -1,0 +1,11 @@
+package repro:repro@0.1.0;
+
+world imports {
+    import wasi:http/types@0.2.1;
+}
+
+package wasi:http@0.2.1 {
+	interface types {
+		type t = u8;
+	}
+}

--- a/testdata/issues/issue281.wit
+++ b/testdata/issues/issue281.wit
@@ -1,4 +1,4 @@
-package repro:repro@0.1.0;
+package issues:issue281@0.1.0;
 
 world imports {
     import wasi:http/types@0.2.1;

--- a/testdata/issues/issue281.wit.json
+++ b/testdata/issues/issue281.wit.json
@@ -1,0 +1,53 @@
+{
+  "worlds": [
+    {
+      "name": "imports",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 1
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "types",
+      "types": {
+        "t": 0
+      },
+      "functions": {},
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "t",
+      "kind": {
+        "type": "u8"
+      },
+      "owner": {
+        "interface": 0
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "wasi:http@0.2.1",
+      "interfaces": {
+        "types": 0
+      },
+      "worlds": {}
+    },
+    {
+      "name": "repro:repro@0.1.0",
+      "interfaces": {},
+      "worlds": {
+        "imports": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue281.wit.json
+++ b/testdata/issues/issue281.wit.json
@@ -43,7 +43,7 @@
       "worlds": {}
     },
     {
-      "name": "repro:repro@0.1.0",
+      "name": "issues:issue281@0.1.0",
       "interfaces": {},
       "worlds": {
         "imports": 0

--- a/testdata/issues/issue281.wit.json.golden.wit
+++ b/testdata/issues/issue281.wit.json.golden.wit
@@ -1,0 +1,11 @@
+package repro:repro@0.1.0;
+
+world imports {
+	import wasi:http/types@0.2.1;
+}
+
+package wasi:http@0.2.1 {
+	interface types {
+		type t = u8;
+	}
+}

--- a/testdata/issues/issue281.wit.json.golden.wit
+++ b/testdata/issues/issue281.wit.json.golden.wit
@@ -1,4 +1,4 @@
-package repro:repro@0.1.0;
+package issues:issue281@0.1.0;
 
 world imports {
 	import wasi:http/types@0.2.1;

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -2400,10 +2400,10 @@ func (g *generator) componentEmbed(witData string) ([]byte, error) {
 	defer cancel()
 
 	// TODO: --all-features?
-	filename := "./component.wit"
+	filename := "component.wit"
 	args := []string{"component", "embed", "--only-custom", filename}
 	fsMap := map[string]fs.FS{
-		".": fstest.MapFS{
+		"": fstest.MapFS{
 			filename: &fstest.MapFile{Data: []byte(witData)},
 		},
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -20,6 +20,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/tetratelabs/wazero/sys"
 	"go.bytecodealliance.org/cm"
 	"go.bytecodealliance.org/internal/codec"
@@ -2423,6 +2424,7 @@ func synthesizeWorld(r *wit.Resolve, w *wit.World, name string) (*wit.Resolve, *
 	p := &wit.Package{}
 	p.Name.Namespace = "go"
 	p.Name.Package = "bindgen"
+	p.Name.Version = &semver.Version{Major: 1}
 
 	w = w.Clone()
 	w.Name = name

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -2372,7 +2372,6 @@ func (g *generator) newPackage(w *wit.World, i *wit.Interface, name string) (*ge
 		}
 		content, err := g.componentEmbed(witText)
 		if err != nil {
-			// g.opts.logger.Errorf("%v", err)
 			g.opts.logger.Errorf("WIT:\n%s\n\n", witText)
 			return nil, err
 		}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -2372,8 +2372,9 @@ func (g *generator) newPackage(w *wit.World, i *wit.Interface, name string) (*ge
 		}
 		content, err := g.componentEmbed(witText)
 		if err != nil {
-			g.opts.logger.Errorf("%v", err)
-			// return nil, err
+			// g.opts.logger.Errorf("%v", err)
+			g.opts.logger.Errorf("WIT:\n%s\n\n", witText)
+			return nil, err
 		}
 		componentType := &wasm.CustomSection{
 			Name:     "component-type:" + worldName,

--- a/wit/bindgen/testdata_test.go
+++ b/wit/bindgen/testdata_test.go
@@ -21,6 +21,7 @@ import (
 	"go.bytecodealliance.org/internal/go/gen"
 	"go.bytecodealliance.org/internal/relpath"
 	"go.bytecodealliance.org/wit"
+	"go.bytecodealliance.org/wit/logging"
 )
 
 var writeGoFiles = flag.Bool("write", false, "write generated Go files")
@@ -108,6 +109,7 @@ func validateGeneratedGo(t *testing.T, res *wit.Resolve, origin string) {
 		GeneratedBy("test"),
 		PackageRoot(pkgPath),
 		Versioned(true),
+		Logger(logging.NewLogger(os.Stderr, logging.LevelWarn)),
 	)
 	if err != nil {
 		t.Error(err)

--- a/wit/ident.go
+++ b/wit/ident.go
@@ -34,6 +34,7 @@ type Ident struct {
 // returning any errors encountered. The resulting Ident
 // may not be valid.
 func ParseIdent(s string) (Ident, error) {
+	s = strings.ReplaceAll(s, "%", "")
 	var id Ident
 	name, ver, hasVer := strings.Cut(s, "@")
 	base, ext, hasExt := strings.Cut(name, "/")

--- a/wit/ident.go
+++ b/wit/ident.go
@@ -108,10 +108,10 @@ func validateName(s string) error {
 				return errors.New("invalid character " + strconv.Quote(string(c)))
 			}
 		case c == '-':
-			switch {
-			case prev == 0: // start of string
+			switch prev {
+			case 0: // start of string
 				return errors.New("invalid leading -")
-			case prev == '-':
+			case '-':
 				return errors.New("invalid double --")
 			}
 		default:

--- a/wit/ident.go
+++ b/wit/ident.go
@@ -68,15 +68,15 @@ func (id *Ident) String() string {
 		return id.UnversionedString()
 	}
 	if id.Extension == "" {
-		return id.Namespace + ":" + id.Package + "@" + id.Version.String()
+		return escape(id.Namespace) + ":" + escape(id.Package) + "@" + id.Version.String()
 	}
-	return id.Namespace + ":" + id.Package + "/" + id.Extension + "@" + id.Version.String()
+	return escape(id.Namespace) + ":" + escape(id.Package) + "/" + escape(id.Extension) + "@" + id.Version.String()
 }
 
 // UnversionedString returns a string representation of an [Ident] without version information.
 func (id *Ident) UnversionedString() string {
 	if id.Extension == "" {
-		return id.Namespace + ":" + id.Package
+		return escape(id.Namespace) + ":" + escape(id.Package)
 	}
-	return id.Namespace + ":" + id.Package + "/" + id.Extension
+	return escape(id.Namespace) + ":" + escape(id.Package) + "/" + escape(id.Extension)
 }

--- a/wit/ident_test.go
+++ b/wit/ident_test.go
@@ -18,6 +18,12 @@ func TestIdent(t *testing.T) {
 		{"wasi:io/streams", Ident{Namespace: "wasi", Package: "io", Extension: "streams"}, false},
 		{"wasi:io/streams@0.2.0", Ident{Namespace: "wasi", Package: "io", Extension: "streams", Version: semver.New("0.2.0")}, false},
 
+		// Escaping
+		{"%use:%own", Ident{Namespace: "use", Package: "own"}, false},
+		{"%use:%own@0.2.0", Ident{Namespace: "use", Package: "own", Version: semver.New("0.2.0")}, false},
+		{"%use:%own/%type", Ident{Namespace: "use", Package: "own", Extension: "type"}, false},
+		{"%use:%own/%type@0.2.0", Ident{Namespace: "use", Package: "own", Extension: "type", Version: semver.New("0.2.0")}, false},
+
 		// Errors
 		{"", Ident{}, true},
 		{":", Ident{}, true},

--- a/wit/ident_test.go
+++ b/wit/ident_test.go
@@ -24,6 +24,10 @@ func TestIdent(t *testing.T) {
 		{"%use:%own/%type", Ident{Namespace: "use", Package: "own", Extension: "type"}, false},
 		{"%use:%own/%type@0.2.0", Ident{Namespace: "use", Package: "own", Extension: "type", Version: semver.New("0.2.0")}, false},
 
+		// Mixed-case
+		{"ABC:def-GHI", Ident{Namespace: "ABC", Package: "def-GHI"}, false},
+		{"ABC1:def2-GHI3", Ident{Namespace: "ABC1", Package: "def2-GHI3"}, false},
+
 		// Errors
 		{"", Ident{}, true},
 		{":", Ident{}, true},
@@ -35,6 +39,14 @@ func TestIdent(t *testing.T) {
 		{"wasi:clocks@", Ident{}, true},
 		{"wasi:clocks/wall-clock@", Ident{}, true},
 		{"foo%:bar%baz", Ident{Namespace: "foo%", Package: "bar%baz"}, true},
+		{"-foo:bar", Ident{Namespace: "-foo", Package: "bar"}, true},
+		{"foo-:bar", Ident{Namespace: "foo-", Package: "bar"}, true},
+		{"foo--foo:bar", Ident{Namespace: "foo--foo", Package: "bar"}, true},
+		{"aBc:bar", Ident{Namespace: "aBc", Package: "bar"}, true},
+		{"1:2", Ident{Namespace: "1", Package: "2"}, true},
+		{"1a:2b", Ident{Namespace: "1a", Package: "2b"}, true},
+		{"foo-1:bar", Ident{Namespace: "foo-1", Package: "bar"}, true},
+		{"foo:bar-1", Ident{Namespace: "foo", Package: "bar-2"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {

--- a/wit/ident_test.go
+++ b/wit/ident_test.go
@@ -34,6 +34,7 @@ func TestIdent(t *testing.T) {
 		{"wasi:/", Ident{}, true},
 		{"wasi:clocks@", Ident{}, true},
 		{"wasi:clocks/wall-clock@", Ident{}, true},
+		{"foo%:bar%baz", Ident{Namespace: "foo%", Package: "bar%baz"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -578,7 +578,7 @@ func relativeName(o TypeOwner, p *Package) string {
 		return ""
 	}
 	qualifiedName := op.Name
-	qualifiedName.Package += "/" + name
+	qualifiedName.Package += "/" + escape(name)
 	return qualifiedName.String()
 }
 


### PR DESCRIPTION
Errors from `wasm-tools` were being silently swallowed, masking a number of related issues:

1. WIT keywords in qualified interface or package names (like `import foo:foo/flags` were not being escaped (`foo:foo/%flags`).
2. Errors from `wasm-tools` invocations (in wasm) were being silently ignored. They are now logged and returned. Errors returned from `wasm-tools component embed` are now fatal.
3. Testdata tests in package `wit/bindgen` now supply a logger to `Go()`.

The synthetic world now uses the original WIT package, to allow inline `import foo: interface { ... }` with inline `use` statements that refer to other interfaces or worlds in the same package.

Fixes #281.