### PR TITLE
wit: fix ABI alignment of list<T> to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - [#281](https://github.com/bytecodealliance/go-modules/issues/281): errors from internal `wasm-tools` calls are no longer silently ignored. This required fixing a number of related issues, including synthetic world packages for Component Model metadata generation, WIT generation, and WIT keyword escaping in WIT package or interface names.
 - [#284](https://github.com/bytecodealliance/go-modules/issues/284): do not use `bool` for `variant` or `result` GC shapes. TinyGo returns `result` and `variant` values with `bool` as 0 or 1, which breaks the memory representation of tagged unions (variants).
+- [#288](https://github.com/bytecodealliance/go-modules/issues/288): correctly report the `wasm32` ABI alignment of `list<T>` as 4, rather than 8.
 
 ## [v0.5.0] — 2024-12-14
 

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -880,11 +880,12 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, t *wit.TypeDef
 	}
 
 	disc := wit.Discriminant(len(v.Cases))
-	shape := variantShape(v.Types())
-	align := variantAlign(v.Types())
+	types := v.Types()
+	shape := variantShape(types)
+	align := variantAlign(types)
 
 	var typeShape string
-	if len(v.Types()) == 1 {
+	if len(types) == 1 {
 		typeShape = g.typeRep(file, dir, shape)
 	} else {
 		typeShape = g.typeShape(file, dir, shape)

--- a/wit/list.go
+++ b/wit/list.go
@@ -17,7 +17,7 @@ func (*List) Size() uintptr { return 8 } // [2]int32
 // Align returns the [ABI byte alignment] a [List].
 //
 // [ABI byte alignment]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
-func (*List) Align() uintptr { return 8 } // [2]int32
+func (*List) Align() uintptr { return 4 }
 
 // Flat returns the [flattened] ABI representation of [List].
 //

--- a/wit/list_test.go
+++ b/wit/list_test.go
@@ -1,0 +1,12 @@
+package wit
+
+import "testing"
+
+// https://github.com/bytecodealliance/go-modules/issues/288
+func TestListAlign(t *testing.T) {
+	var l List
+	got, want := l.Align(), uintptr(4)
+	if got != want {
+		t.Errorf("ABI alignment for list<T> is %d, expected %d", got, want)
+	}
+}


### PR DESCRIPTION
- **wit: change the ABI alignment of list<T> from 8 to 4**
- **wit/bindgen: call v.Types() once**
- **CHANGELOG: add note about #288**
