### PR TITLE
cm: Use public type for errorContext wasm functions

### DIFF
--- a/cm/error.go
+++ b/cm/error.go
@@ -28,7 +28,7 @@ func (err errorContext) String() string {
 // [error-context.debug-message]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#error-contextdebug-message
 func (err errorContext) DebugMessage() string {
 	var s string
-	wasmimport_errorContextDebugMessage(err, unsafe.Pointer(&s))
+	wasmimport_errorContextDebugMessage(uint32(err), unsafe.Pointer(&s))
 	return s
 }
 
@@ -36,5 +36,5 @@ func (err errorContext) DebugMessage() string {
 //
 // [error-context.drop]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#error-contextdrop
 func (err errorContext) Drop() {
-	wasmimport_errorContextDrop(err)
+	wasmimport_errorContextDrop(uint32(err))
 }

--- a/cm/error.wasm.go
+++ b/cm/error.wasm.go
@@ -6,8 +6,8 @@ import "unsafe"
 //
 //go:wasmimport canon error-context.debug-message
 //go:noescape
-func wasmimport_errorContextDebugMessage(err errorContext, msg unsafe.Pointer)
+func wasmimport_errorContextDebugMessage(err uint32, msg unsafe.Pointer)
 
 //go:wasmimport canon error-context.drop
 //go:noescape
-func wasmimport_errorContextDrop(err errorContext)
+func wasmimport_errorContextDrop(err uint32)


### PR DESCRIPTION
[wadge](https://github.com/wasmCloud/wadge) ( Test Harness generator ) scans all generated code and no longer works with cm package version 2.x.

code generated via wit-bindgen-go uses Public Types for wasmimport/export functions.
The newly introduced `ErrorContext` in `cm` uses a private type ( `errorContext` ), making it impossible to shim it with `go:linkname`.

```
# github.com/wasmCloud/go/examples/component/http-server_test [github.com/wasmCloud/go/examples/component/http-server.test]
./bindings.wadge_test.go:24:78: name errorContext not exported by package cm
./bindings.wadge_test.go:44:70: name errorContext not exported by package cm
FAIL	github.com/wasmCloud/go/examples/component/http-server [build failed]
```

what wadge generates after parsing wit generated code:
![Screenshot 2025-04-23 at 12 05 57 PM](https://github.com/user-attachments/assets/0180ed42-ea2c-4c58-9f84-cf678ab17b57)
