### PR TITLE
Build statically-linked pre-built binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Run Go tests
+        env:
+          # Test with the same environment as the build.
+          CGO_ENABLED: 0
         run: go test ${{ env.go-modules }}
 
       - name: Build binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,9 @@ jobs:
         run: go test ${{ env.go-modules }}
 
       - name: Build binary
+        env:
+          # Disable cgo so the pre-built binary is statically linked for maximum compatibility.
+          CGO_ENABLED: 0
         run: |
           mkdir -p build
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o wit-bindgen-go ./cmd/wit-bindgen-go


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/go-modules/issues/345.

The statically-linked binary is actually smaller (on x86_64-linux at least) by about 60kb.