### PR TITLE
cm: do not use bool discriminant in variant, result, and option types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ generated: clean json
 clean:
 	rm -rf ./generated/*
 	rm -f internal/wasmtools/wasm-tools.wasm
-	rm -f internal/wasmtools/wasm-tools.wasm.gz
 
 # tests/generated writes generated Go code to the tests directory
 .PHONY: tests/generated

--- a/cm/CHANGELOG.md
+++ b/cm/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Breaking: `BoolResult` is now represented as a `uint8` rather than a `bool`. This fixes an issue with TinyGo where `bool` values are treated distinctly from `uint8`. See [#344](https://github.com/bytecodealliance/go-modules/issues/344) for more information.
 - Mutating methods `SetOK` and `SetErr` on `result` types (`Result[Shape, OK, Err]`).
+
+### Changed
+
+- Breaking: `BoolResult` is now represented as a `uint8` rather than a `bool`. This fixes an issue with TinyGo where `bool` values are treated distinctly from `uint8`. See [#344](https://github.com/bytecodealliance/go-modules/issues/344) for more information.
 
 ### Fixed
 
-- [#344](https://github.com/bytecodealliance/go-modules/issues/344): the memory representation of `option`, `result` now use `uint8` instead of `bool` for the discriminator. LLVM optimizes `bool` values into a single bit, which breaks WIT variants where the associated types share memory.
+- [#344](https://github.com/bytecodealliance/go-modules/issues/344): the memory representation of `option` and `result` now use `uint8` instead of `bool` for the discriminator. LLVM optimizes `bool` values into a single bit, which breaks WIT variants where the associated types share memory.
 
 ## [v0.2.2] — 2025-03-16
 

--- a/cm/CHANGELOG.md
+++ b/cm/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Breaking: `BoolResult` is now represented as a `uint8` rather than a `bool`. This fixes an issue with TinyGo where `bool` values are treated distinctly from `uint8`. See [#344](https://github.com/bytecodealliance/go-modules/issues/344) for more information.
 - Mutating methods `SetOK` and `SetErr` on `result` types (`Result[Shape, OK, Err]`).
+
+### Fixed
+
+- [#344](https://github.com/bytecodealliance/go-modules/issues/344): the memory representation of `option`, `result` now use `uint8` instead of `bool` for the discriminator. LLVM optimizes `bool` values into a single bit, which breaks WIT variants where the associated types share memory.
 
 ## [v0.2.2] — 2025-03-16
 

--- a/cm/option.go
+++ b/cm/option.go
@@ -18,7 +18,7 @@ func None[T any]() Option[T] {
 func Some[T any](v T) Option[T] {
 	return Option[T]{
 		option: option[T]{
-			isSome: true,
+			isSome: 1,
 			some:   v,
 		},
 	}
@@ -29,19 +29,19 @@ func Some[T any](v T) Option[T] {
 // followed by storage for the associated type T.
 type option[T any] struct {
 	_      HostLayout
-	isSome bool
+	isSome uint8
 	some   T
 }
 
 // None returns true if o represents the none case.
 func (o *option[T]) None() bool {
-	return !o.isSome
+	return o.isSome == 0
 }
 
 // Some returns a non-nil *T if o represents the some case,
 // or nil if o represents the none case.
 func (o *option[T]) Some() *T {
-	if o.isSome {
+	if o.isSome == 1 {
 		return &o.some
 	}
 	return nil
@@ -51,7 +51,7 @@ func (o *option[T]) Some() *T {
 // or the zero value of T if o represents the none case.
 // This does not have a pointer receiver, so it can be chained.
 func (o option[T]) Value() T {
-	if !o.isSome {
+	if o.isSome == 0 {
 		var zero T
 		return zero
 	}

--- a/cm/option.go
+++ b/cm/option.go
@@ -25,7 +25,7 @@ func Some[T any](v T) Option[T] {
 }
 
 // option represents the internal representation of a Component Model option type.
-// The first byte is a bool representing none or some,
+// The first byte is a byte representing the none or some case,
 // followed by storage for the associated type T.
 type option[T any] struct {
 	_      HostLayout

--- a/cm/result.go
+++ b/cm/result.go
@@ -44,7 +44,7 @@ type result[Shape, OK, Err any] struct {
 func OK[R AnyResult[Shape, OK, Err], Shape, OK, Err any](ok OK) R {
 	var r Result[Shape, OK, Err]
 	r.validate()
-	r.isErr = 0
+	r.isErr = ResultOK
 	*((*OK)(unsafe.Pointer(&r.data))) = ok
 	return R(r)
 }
@@ -54,7 +54,7 @@ func OK[R AnyResult[Shape, OK, Err], Shape, OK, Err any](ok OK) R {
 func Err[R AnyResult[Shape, OK, Err], Shape, OK, Err any](err Err) R {
 	var r Result[Shape, OK, Err]
 	r.validate()
-	r.isErr = 1
+	r.isErr = ResultErr
 	*((*Err)(unsafe.Pointer(&r.data))) = err
 	return R(r)
 }
@@ -62,34 +62,34 @@ func Err[R AnyResult[Shape, OK, Err], Shape, OK, Err any](err Err) R {
 // SetOK sets r to an OK result.
 func (r *result[Shape, OK, Err]) SetOK(ok OK) {
 	r.validate()
-	r.isErr = 0
+	r.isErr = ResultOK
 	*((*OK)(unsafe.Pointer(&r.data))) = ok
 }
 
 // SetErr sets r to an error result.
 func (r *result[Shape, OK, Err]) SetErr(err Err) {
 	r.validate()
-	r.isErr = 1
+	r.isErr = ResultErr
 	*((*Err)(unsafe.Pointer(&r.data))) = err
 }
 
 // IsOK returns true if r represents the OK case.
 func (r *result[Shape, OK, Err]) IsOK() bool {
 	r.validate()
-	return r.isErr == 0
+	return r.isErr == ResultOK
 }
 
 // IsErr returns true if r represents the error case.
 func (r *result[Shape, OK, Err]) IsErr() bool {
 	r.validate()
-	return r.isErr == 1
+	return r.isErr == ResultErr
 }
 
 // OK returns a non-nil *OK pointer if r represents the OK case.
 // If r represents an error, then it returns nil.
 func (r *result[Shape, OK, Err]) OK() *OK {
 	r.validate()
-	if r.isErr == 1 {
+	if r.isErr == ResultErr {
 		return nil
 	}
 	return (*OK)(unsafe.Pointer(&r.data))
@@ -99,7 +99,7 @@ func (r *result[Shape, OK, Err]) OK() *OK {
 // If r represents the OK case, then it returns nil.
 func (r *result[Shape, OK, Err]) Err() *Err {
 	r.validate()
-	if r.isErr == 0 {
+	if r.isErr == ResultOK {
 		return nil
 	}
 	return (*Err)(unsafe.Pointer(&r.data))
@@ -109,7 +109,7 @@ func (r *result[Shape, OK, Err]) Err() *Err {
 // or (zero value of OK, Err, true) if r represents the error case.
 // This does not have a pointer receiver, so it can be chained.
 func (r result[Shape, OK, Err]) Result() (ok OK, err Err, isErr bool) {
-	if r.isErr == 1 {
+	if r.isErr == ResultErr {
 		return ok, *(*Err)(unsafe.Pointer(&r.data)), true
 	}
 	return *(*OK)(unsafe.Pointer(&r.data)), err, false

--- a/cm/result.go
+++ b/cm/result.go
@@ -4,15 +4,15 @@ import "unsafe"
 
 const (
 	// ResultOK represents the OK case of a result.
-	ResultOK = false
+	ResultOK = 0
 
 	// ResultErr represents the error case of a result.
-	ResultErr = true
+	ResultErr = 1
 )
 
 // BoolResult represents a result with no OK or error type.
 // False represents the OK case and true represents the error case.
-type BoolResult bool
+type BoolResult uint8
 
 // Result represents a result sized to hold the Shape type.
 // The size of the Shape type must be greater than or equal to the size of OK and Err types.

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -350,3 +350,28 @@ func TestIssue284NotTinyGo(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue344TupleOfOption(t *testing.T) {
+	type T Result[[1]Option[uint64], uint64, [1]Option[uint64]]
+
+	want := uint64(2)
+	v := T(OK[Result[[1]Option[uint64], uint64, [1]Option[uint64]]](want))
+	got := *v.OK()
+
+	if got != want {
+		t.Errorf("*v.OK(): %v, expected %v", got, want)
+	}
+}
+
+func TestIssue344TupleOfResult(t *testing.T) {
+	type R Result[uint64, uint64, bool]
+	type T Result[[1]R, uint64, [1]R]
+
+	want := uint64(2)
+	v := T(OK[T](want))
+	got := *v.OK()
+
+	if got != want {
+		t.Errorf("*v.OK(): %v, expected %v", got, want)
+	}
+}

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -351,11 +351,11 @@ func TestIssue284NotTinyGo(t *testing.T) {
 	}
 }
 
-func TestIssue344TupleOfOption(t *testing.T) {
-	type T Result[[1]Option[uint64], uint64, [1]Option[uint64]]
+func TestIssue344Option(t *testing.T) {
+	type T Result[Option[uint64], uint64, Option[uint64]]
 
 	want := uint64(2)
-	v := T(OK[Result[[1]Option[uint64], uint64, [1]Option[uint64]]](want))
+	v := T(OK[Result[Option[uint64], uint64, Option[uint64]]](want))
 	got := *v.OK()
 
 	if got != want {
@@ -363,9 +363,9 @@ func TestIssue344TupleOfOption(t *testing.T) {
 	}
 }
 
-func TestIssue344TupleOfResult(t *testing.T) {
+func TestIssue344Result(t *testing.T) {
 	type R Result[uint64, uint64, bool]
-	type T Result[[1]R, uint64, [1]R]
+	type T Result[R, uint64, R]
 
 	want := uint64(2)
 	v := T(OK[T](want))

--- a/cm/result_test.go
+++ b/cm/result_test.go
@@ -87,7 +87,7 @@ func TestResultLayout(t *testing.T) {
 		size   uintptr
 		offset uintptr
 	}{
-		{"result", BoolResult(false), 1, 0},
+		{"result", BoolResult(0), 1, 0},
 		{"ok", BoolResult(ResultOK), 1, 0},
 		{"err", BoolResult(ResultErr), 1, 0},
 
@@ -368,6 +368,18 @@ func TestIssue344TupleOfResult(t *testing.T) {
 	type T Result[[1]R, uint64, [1]R]
 
 	want := uint64(2)
+	v := T(OK[T](want))
+	got := *v.OK()
+
+	if got != want {
+		t.Errorf("*v.OK(): %v, expected %v", got, want)
+	}
+}
+
+func TestIssue344BoolResult(t *testing.T) {
+	type T Result[BoolResult, uint8, BoolResult]
+
+	want := uint8(2)
 	v := T(OK[T](want))
 	got := *v.OK()
 

--- a/testdata/issues/issue344.wit
+++ b/testdata/issues/issue344.wit
@@ -1,0 +1,15 @@
+package issues:issue344;
+
+world w {
+    import i;
+}
+
+interface i {
+	type a = result<u64, tuple<option<u64>>>;
+	type b = result<u64, tuple<result<u64, bool>>>;
+	type c = result<result, u8>;
+
+	fa: func() -> a;
+	fb: func() -> b;
+	fc: func() -> c;
+}

--- a/testdata/issues/issue344.wit.json
+++ b/testdata/issues/issue344.wit.json
@@ -1,0 +1,145 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {},
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i",
+      "types": {
+        "a": 2,
+        "b": 5,
+        "c": 7
+      },
+      "functions": {
+        "fa": {
+          "name": "fa",
+          "kind": "freestanding",
+          "params": [],
+          "result": 2
+        },
+        "fb": {
+          "name": "fb",
+          "kind": "freestanding",
+          "params": [],
+          "result": 5
+        },
+        "fc": {
+          "name": "fc",
+          "kind": "freestanding",
+          "params": [],
+          "result": 7
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": null,
+      "kind": {
+        "option": "u64"
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "tuple": {
+          "types": [
+            0
+          ]
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": "a",
+      "kind": {
+        "result": {
+          "ok": "u64",
+          "err": 1
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "result": {
+          "ok": "u64",
+          "err": "bool"
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "tuple": {
+          "types": [
+            3
+          ]
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": "b",
+      "kind": {
+        "result": {
+          "ok": "u64",
+          "err": 4
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "result": {
+          "ok": null,
+          "err": null
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": "c",
+      "kind": {
+        "result": {
+          "ok": 6,
+          "err": "u8"
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue344",
+      "interfaces": {
+        "i": 0
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue344.wit.json.golden.wit
+++ b/testdata/issues/issue344.wit.json.golden.wit
@@ -1,0 +1,14 @@
+package issues:issue344;
+
+interface i {
+	type a = result<u64, tuple<option<u64>>>;
+	type b = result<u64, tuple<result<u64, bool>>>;
+	type c = result<result, u8>;
+	fa: func() -> a;
+	fb: func() -> b;
+	fc: func() -> c;
+}
+
+world w {
+	import i;
+}

--- a/tests/generated/wasi/cli/v0.2.0/exit/exit.wit.go
+++ b/tests/generated/wasi/cli/v0.2.0/exit/exit.wit.go
@@ -15,7 +15,7 @@ import (
 //
 //go:nosplit
 func Exit(status cm.BoolResult) {
-	status0 := (uint32)(cm.BoolToU32(status))
+	status0 := (uint32)(status)
 	wasmimport_Exit((uint32)(status0))
 	return
 }

--- a/tests/generated/wasi/cli/v0.2.0/run/run.wasm.go
+++ b/tests/generated/wasi/cli/v0.2.0/run/run.wasm.go
@@ -2,16 +2,12 @@
 
 package run
 
-import (
-	"go.bytecodealliance.org/cm"
-)
-
 // This file contains wasmimport and wasmexport declarations for "wasi:cli@0.2.0".
 
 //go:wasmexport wasi:cli/run@0.2.0#run
 //export wasi:cli/run@0.2.0#run
 func wasmexport_Run() (result0 uint32) {
 	result := Exports.Run()
-	result0 = (uint32)(cm.BoolToU32(result))
+	result0 = (uint32)(result)
 	return
 }

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1036,6 +1036,11 @@ func (g *generator) typeDefShape(file *gen.File, dir wit.Direction, t *wit.TypeD
 			// Variants that can be represented as an enum do not need a custom shape.
 			return g.typeRep(file, dir, t)
 		}
+	case *wit.Result:
+		if len(kind.Types()) == 0 {
+			// Results without associated types do not need a custom shape.
+			return g.typeRep(file, dir, t)
+		}
 	case *wit.Tuple:
 		if kind.Type() != nil {
 			// Monotypic tuples have a packed memory layout.
@@ -1214,7 +1219,7 @@ func (g *generator) lowerVariant(file *gen.File, dir wit.Direction, t *wit.TypeD
 func (g *generator) lowerResult(file *gen.File, dir wit.Direction, t *wit.TypeDef, input string) string {
 	r := t.Kind.(*wit.Result)
 	if r.OK == nil && r.Err == nil {
-		return g.cast(file, dir, wit.Bool{}, wit.U32{}, input)
+		return g.cast(file, dir, wit.U8{}, wit.U32{}, input)
 	}
 	flat := t.Flat()
 	abiFile := g.abiFile(file.Package)
@@ -1425,7 +1430,7 @@ func (g *generator) liftResult(file *gen.File, dir wit.Direction, t *wit.TypeDef
 	r := t.Kind.(*wit.Result)
 	flat := t.Flat()
 	if r.OK == nil && r.Err == nil {
-		return g.cast(file, dir, wit.Bool{}, t, g.cast(file, dir, flat[0], wit.Bool{}, input))
+		return g.cast(file, dir, wit.Bool{}, t, g.cast(file, dir, flat[0], wit.U8{}, input))
 	}
 	abiFile := g.abiFile(file.Package)
 	var b strings.Builder


### PR DESCRIPTION
This PR implements a breaking change: `BoolResult` is now a `uint8` instead of `bool`, due to how LLVM represents a boolean value as a single bit, ignoring the high 7 bits. This breaks variants and other tagged unions if a `bool` is used as the memory shape.

Fixes #344.