### PR TITLE
wit: align record size to max field alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - [#306](https://github.com/bytecodealliance/go-modules/issues/306): do not emit incompatible version feature gates when serializing WIT. For example, if a world with version `0.1.0` *includes* a world from another package with a `@since(version = 0.2.0)` feature gate, then strip that feature gate when serializing to WIT if the version is greater than the world’s package version.
+- [#350](https://github.com/bytecodealliance/go-modules/issues/350): correctly align `record` size to the highest alignment of its fields, per [specification](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size).
 
 
 ## [v0.6.2] — 2025-03-16

--- a/wit/abi.go
+++ b/wit/abi.go
@@ -9,7 +9,7 @@ import (
 // [Canonical ABI] [size], [alignment], and [flat] representation.
 //
 // [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
-// [size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 // [alignment]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
 // [flat]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
 type ABI interface {

--- a/wit/enum.go
+++ b/wit/enum.go
@@ -29,7 +29,7 @@ func (e *Enum) Despecialize() TypeDefKind {
 // type that can represent 0...len(e.Cases).
 // It is first [despecialized] into a [Variant] with no associated types, then sized.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 // [despecialized]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#despecialization
 func (e *Enum) Size() uintptr {
 	return e.Despecialize().Size()

--- a/wit/flags.go
+++ b/wit/flags.go
@@ -11,7 +11,7 @@ type Flags struct {
 
 // Size returns the [ABI byte size] of [Flags] f.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (f *Flags) Size() uintptr {
 	n := len(f.Flags)
 	switch {

--- a/wit/future.go
+++ b/wit/future.go
@@ -12,7 +12,7 @@ type Future struct {
 
 // Size returns the [ABI byte size] for a [Future].
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (*Future) Size() uintptr { return 4 }
 
 // Align returns the [ABI byte alignment] a [Future].

--- a/wit/list.go
+++ b/wit/list.go
@@ -11,7 +11,7 @@ type List struct {
 
 // Size returns the [ABI byte size] for a [List].
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (*List) Size() uintptr { return 8 } // [2]int32
 
 // Align returns the [ABI byte alignment] a [List].

--- a/wit/option.go
+++ b/wit/option.go
@@ -27,7 +27,7 @@ func (o *Option) Despecialize() TypeDefKind {
 // Size returns the [ABI byte size] for [Option] o.
 // It is first [despecialized] into a [Variant] with two cases, "none" and "some(T)", then sized.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 // [despecialized]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#despecialization
 func (o *Option) Size() uintptr {
 	return o.Despecialize().Size()

--- a/wit/pointer.go
+++ b/wit/pointer.go
@@ -14,7 +14,7 @@ type Pointer struct {
 
 // Size returns the [ABI byte size] for [Pointer].
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (*Pointer) Size() uintptr { return 4 }
 
 // Align returns the [ABI byte alignment] for [Pointer].

--- a/wit/record.go
+++ b/wit/record.go
@@ -11,7 +11,7 @@ type Record struct {
 
 // Size returns the [ABI byte size] for [Record] r.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (r *Record) Size() uintptr {
 	var s uintptr
 	for _, f := range r.Fields {

--- a/wit/record.go
+++ b/wit/record.go
@@ -18,7 +18,7 @@ func (r *Record) Size() uintptr {
 		s = Align(s, f.Type.Align())
 		s += f.Type.Size()
 	}
-	return s
+	return Align(s, r.Align())
 }
 
 // Align returns the [ABI byte alignment] for [Record] r.

--- a/wit/resource.go
+++ b/wit/resource.go
@@ -8,7 +8,7 @@ type Resource struct{ _typeDefKind }
 
 // Size returns the [ABI byte size] for [Resource].
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (*Resource) Size() uintptr { return 4 }
 
 // Align returns the [ABI byte alignment] for [Resource].
@@ -45,7 +45,7 @@ func (_handle) isHandle() {}
 
 // Size returns the [ABI byte size] for this [Handle].
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (_handle) Size() uintptr { return 4 }
 
 // Align returns the [ABI byte alignment] for this [Handle].

--- a/wit/result.go
+++ b/wit/result.go
@@ -40,7 +40,7 @@ func (r *Result) Types() []Type {
 // Size returns the [ABI byte size] for [Result] r.
 // It is first [despecialized] into a [Variant] with two cases "ok" and "error", then sized.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 // [despecialized]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#despecialization
 func (r *Result) Size() uintptr {
 	return r.Despecialize().Size()

--- a/wit/stream.go
+++ b/wit/stream.go
@@ -12,7 +12,7 @@ type Stream struct {
 
 // Size returns the [ABI byte size] for a [Stream].
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (*Stream) Size() uintptr { return 4 }
 
 // Align returns the [ABI byte alignment] a [Stream].

--- a/wit/tuple.go
+++ b/wit/tuple.go
@@ -48,7 +48,7 @@ func (t *Tuple) Despecialize() TypeDefKind {
 // Size returns the [ABI byte size] for [Tuple] t.
 // It is first [despecialized] into a [Record] with 0-based integer field names, then sized.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 // [despecialized]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#despecialization
 func (t *Tuple) Size() uintptr {
 	return t.Despecialize().Size()

--- a/wit/variant.go
+++ b/wit/variant.go
@@ -46,7 +46,7 @@ func (v *Variant) Types() []Type {
 
 // Size returns the [ABI byte size] for [Variant] v.
 //
-// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#size
+// [ABI byte size]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
 func (v *Variant) Size() uintptr {
 	s := Discriminant(len(v.Cases)).Size()
 	s = Align(s, v.maxCaseAlign())


### PR DESCRIPTION
Fixes #350.

See https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#element-size
